### PR TITLE
fix: magit-section-heading faces respect s-variable-pitch

### DIFF
--- a/os1-customized.el
+++ b/os1-customized.el
@@ -13,13 +13,13 @@
        ((,class (
                  :underline nil :overline nil
                  :background ,base02 :foreground ,base1
-                 :box (:line-width 8 :color ,base02)))))
+                 :box (:line-width 1 :color ,base02)))))
      `(mode-line-inactive
        ((,class (
                  :underline nil :overline nil
                  :background ,hl-light
                  :foreground ,base01
-                 :box (:line-width 8 :color ,hl-light)))))
+                 :box (:line-width 1 :color ,hl-light)))))
 
      `(font-lock-comment-face ((,class (:foreground ,base00))))
      `(font-lock-keyword-face ((,class (:foreground ,green :weight semibold))))

--- a/os1-customized.el
+++ b/os1-customized.el
@@ -41,6 +41,6 @@
      `(doom-modeline-bar-inactive ((,class :background ,violet-2bg :inherit t)))
 
      `(git-commit-summary ((,class (:foreground ,violet-d))))
-     `(magit-section-heading ((,class (:height 1.2 :foreground ,violet-d :weight semibold :inherit variable-pitch))))
+     `(magit-section-heading ((,class (:height 1.2 :foreground ,violet-d :weight semibold :inherit ,s-variable-pitch))))
      )))
 (provide 'os1-customized)


### PR DESCRIPTION
Solarized has a configuration option to turn on variable pitch faces via
`solarized-use-variable-pitch`. See https://github.com/bbatsov/solarized-emacs/blob/master/solarized-faces.el#L324-L325